### PR TITLE
fix esgf-security postgres-related installation issues

### DIFF
--- a/bin/esg-security
+++ b/bin/esg-security
@@ -182,7 +182,8 @@ configure_postgress() {
         #install the egg....
         source ${cdat_home}/bin/activate esgf-pub
         ((DEBUG)) && "easy_install ${esgf_security_egg_file}"
-        $cdat_home/bin/easy_install ${esgf_security_egg_file}
+        conda install -y postgresql
+        easy_install ${esgf_security_egg_file}
         [ $? != 0 ] && echo "ERROR: Could not create esgf security python module" && checked_done 1
 
         if [ -n "$(postgres_list_db_schemas ${node_db_security_schema_name})" ]; then


### PR DESCRIPTION
Explicitly install `postgresql` into the conda environment rather than rely on version from RPM (which is too old for `psycopg2`).

Also remove path to `easy_install` to ensure that it uses the one from the `esgf-pub` conda environment, not the root environment.

See https://github.com/ESGF/esgf-installer/issues/273 for more detail