### PR TITLE
regexp improvements in policies files

### DIFF
--- a/src/java/main/esg/security/config/esgf_policies_common.xml
+++ b/src/java/main/esg/security/config/esgf_policies_common.xml
@@ -6,18 +6,16 @@
 <policies xmlns="http://www.esgf.org/security">
 
         <!-- Admin-restricted applications. -->
-        <policy resource=".*esgf-dashboard.*" attribute_type="wheel" attribute_value="super" action="Read"/>
-        <policy resource=".*test.*" attribute_type="ANY" attribute_value="" action="Read"/>
-        <policy resource=".*test.*" attribute_type="wheel" attribute_value="super" action="Write"/>
+        <policy resource=".*/esgf-dashboard/.*" attribute_type="wheel" attribute_value="super" action="Read"/>
+        <policy resource=".*/test/.*" attribute_type="wheel" attribute_value="super" action="Write"/>
         
-        <!-- Test resources are made freely available 
-        <policy resource=".*test.*" attribute_type="ANY" attribute_value="" action="Read"/>
-        <policy resource=".*test.*" attribute_type="Test_Group" attribute_value="publisher" action="Write"/> -->
-        <policy resource=".*test.*" attribute_type="wheel" attribute_value="super" action="Write"/>
-        <!-- <policy resource=".*test.*" attribute_type="Test Group" attribute_value="User" action="Read"/> -->
+        <!-- Test resources are made freely available -->
+        <policy resource=".*/test/.*" attribute_type="ANY" attribute_value="" action="Read"/>
+        <policy resource=".*/test/.*" attribute_type="Test_Group" attribute_value="publisher" action="Write"/>
+        <!-- <policy resource=".*/test/.*" attribute_type="Test Group" attribute_value="User" action="Read"/> -->
 
         <!-- Everything is Free 
              Leeave this statement commented out unless you are testing data download.
-        <policy resource=".*esg_dataroot.*" attribute_type="ANY" attribute_value="" action="Read"/> -->
+        <policy resource=".*/esg_dataroot/.*" attribute_type="ANY" attribute_value="" action="Read"/> -->
 
 </policies>

--- a/src/java/main/esg/security/config/esgf_policies_local.xml
+++ b/src/java/main/esg/security/config/esgf_policies_local.xml
@@ -5,23 +5,23 @@
      It will not be overridden by a software update. -->
 <policies xmlns="http://www.esgf.org/security">
 
-    <!-- The following statements allow all members of group "CMIP5 Research" or "CMIP5 Commercial" to read any local URL that contains "cmip5".
+    <!-- The following statements allow all members of group "CMIP5 Research" or "CMIP5 Commercial" to read any local URL that contains "/cmip5/".
          Note that the groups "CMIP5 Research" and "CMIP5 Commercial" are administered by PCMDI -->
-    <!-- <policy resource=".*cmip5.*" attribute_type="CMIP5 Research" attribute_value="user" action="Read"/> -->
-    <!-- <policy resource=".*cmip5.*" attribute_type="CMIP5 Commercial" attribute_value="user" action="Read"/> -->
+    <!-- <policy resource=".*/cmip5/.*" attribute_type="CMIP5 Research" attribute_value="user" action="Read"/> -->
+    <!-- <policy resource=".*/cmip5/.*" attribute_type="CMIP5 Commercial" attribute_value="user" action="Read"/> -->
     <!-- These statements provide CMIP5 Read access for members of the old gateways -->
-    <!-- <policy resource=".*cmip5.*" attribute_type="CMIP5 Research" attribute_value="default" action="Read"/> -->
-    <!-- <policy resource=".*cmip5.*" attribute_type="CMIP5 Commercial" attribute_value="default" action="Read"/> -->
+    <!-- <policy resource=".*/cmip5/.*" attribute_type="CMIP5 Research" attribute_value="default" action="Read"/> -->
+    <!-- <policy resource=".*/cmip5/.*" attribute_type="CMIP5 Commercial" attribute_value="default" action="Read"/> -->
     
 
-    <!-- The following statement allows all members of group "MY GROUP" to read any local URL that contains "my_data"
-    <policy resource=".*my_data.*" attribute_type="MY GROUP" attribute_value="user" action="Read"/> -->
+    <!-- The following statement allows all members of group "MY GROUP" to read any local URL that contains "/my_data/"
+    <policy resource=".*/my_data/.*" attribute_type="MY GROUP" attribute_value="user" action="Read"/> -->
     
-    <!-- The following statement allows members of group "MY GROUP" with role="publisher" to publish local datasets with id containing "my_data" 
-    <policy resource=".*my_data.*" attribute_type="MY GROUP" attribute_value="publisher" action="Write"/> -->
+    <!-- The following statement allows members of group "MY GROUP" with role="publisher" to publish local datasets with id containing "/my_data/" 
+    <policy resource=".*/my_data/.*" attribute_type="MY GROUP" attribute_value="publisher" action="Write"/> -->
     
-    <!-- The following statements makes resources that contain '.*test.*' freely available for download -->
-    <!-- <policy resource=".*test.*" attribute_type="ANY" attribute_value="" action="Read"/> -->
+    <!-- The following statements makes resources that contain '/test/' freely available for download -->
+    <!-- <policy resource=".*/test/.*" attribute_type="ANY" attribute_value="" action="Read"/> -->
     
     <!-- The following statements makes all resources freely available for download -->
     <!-- <policy resource=".*" attribute_type="ANY" attribute_value="" action="Read"/> -->


### PR DESCRIPTION
In the policies files:

- Some cleanup between the "admin" and "test resources" sections.

- Change the regexps to add slashes, so that "test" (etc) needs to be the
  name of a directory, likewise for "cmip5". This will be the case, as
  the filesystem will be laid out according to the DRS.  Without this,
  `.*test.*` matches *all* URLs on any test node with "test" in the hostname,
  meaning that node admin would have to edit the "common" policies file every
  time the software is updated.