### PR TITLE
Remove SQLalchemy requirement to accomodate sqlalchemy_migrate 0.12.0

### DIFF
--- a/src/python/esgf/setup.py.tmpl
+++ b/src/python/esgf/setup.py.tmpl
@@ -16,7 +16,7 @@ setup(
     author = 'ESGF Software Team',
     author_email = 'esgf-mechanic@lists.llnl.gov',
     url = 'http://esgf.org',
-    install_requires = ["psycopg2>=2.0", "SQLAlchemy>=0.5.3, <=0.7.10", "sqlalchemy_migrate>=0.6"],
+    install_requires = ["psycopg2>=2.0", "sqlalchemy_migrate>=0.6"],
     #setup_requires = ["psycopg2>=2.0", "SQLAlchemy>=0.5.3", "sqlalchemy_migrate>=0.6"],
     dependency_links = ["http://rainbow.llnl.gov/dist/externals"],
     packages = find_packages(exclude=['ez_setup']),


### PR DESCRIPTION
There is a hard version requirement conflict for SQLAlchemy, between our specification and that of sqlalchemy-migrate 0.12.0. It is causing errors during installation. 

sqlalchemy_migrate 0.12.0 was just released early today: https://pypi.org/project/sqlalchemy-migrate/

Our requirements are 6 years old, made in this commit: https://github.com/ESGF/esgf-security/commit/0146ca24793c01bb959ea551937f76856c4d4388

The problem stated in that above commit was said to be resolved here, a couple months later: https://github.com/ESGF/esgf-security/commit/61573813078853e8b8376a4242f0308400de6ca3



This issue may be present in all of our migration scripts.

This solution has not been tested as a build is required.